### PR TITLE
Add auto publish functionality

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: publish
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.11
+      - run: |
+          pip install poetry
+          poetry version ${GITHUB_REF##*/v}
+          poetry build
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./dist
+
+  pypi-publish:
+    needs: ['build']
+    environment: 'publish'
+
+    name: Upload Release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v3
+      - name: Publish Package Distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages_dir: artifact/


### PR DESCRIPTION
# Description

Added a publish.yml file in the .github/workflows directory expected to facilitate automatic publishing to PyPI when a new release is created in the repo here.

Fixes #19

## Type of change

Please delete options that are not relevant.

- [X] New feature *(non-breaking change which adds functionality)*

# How Has This Been Tested?

- [X] This PR does not need tested
